### PR TITLE
fix array out of bounds when double-clicking an album with no tracks (yet) loaded

### DIFF
--- a/Submariner/SBPlayer.swift
+++ b/Submariner/SBPlayer.swift
@@ -517,7 +517,9 @@ extension NSNotification.Name {
     }
     
     @objc(playTrackByIndex:) func play(index: Int) {
-        play(track: playlist[index], index: index)
+        if index < playlist.count {
+            play(track: playlist[index], index: index)
+        }
     }
     
     private func play(track: SBTrack, index: Int) {


### PR DESCRIPTION
I'm unsure if this is the proper way to handle this but at least it doesn't crash anymore.