### PR TITLE
Further reduce CPU usage when refreshing UI

### DIFF
--- a/Submariner/SBDatabaseController.m
+++ b/Submariner/SBDatabaseController.m
@@ -981,6 +981,11 @@
             return;
         }
         
+        BOOL visible = self.window.occlusionState & NSWindowOcclusionStateVisible;
+        if (!visible) {
+            return;
+        }
+
         [progressSlider setEnabled:YES];
         NSString *currentTimeString = [[SBPlayer sharedInstance] currentTimeString];
         NSString *remainingTimeString = [[SBPlayer sharedInstance] remainingTimeString];

--- a/Submariner/SBDatabaseController.m
+++ b/Submariner/SBDatabaseController.m
@@ -159,6 +159,8 @@
     // remove Subsonic observers
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"SBSubsonicConnectionSucceededNotification" object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"SBSubsonicConnectionFailedNotification" object:nil];
+    // remove window observers
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowDidChangeOcclusionStateNotification object:nil];
     // remove queue operations observer
     [[NSOperationQueue sharedServerQueue] removeObserver:self forKeyPath:@"operationCount"];
     [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/Submariner/SBDatabaseController.m
+++ b/Submariner/SBDatabaseController.m
@@ -256,16 +256,12 @@
                                                  name:@"SBSubsonicConnectionFailedNotification"
                                                object:nil];
 
-    // observe application state
+    // observe window state
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(windowDidMiniaturize:)
-                                                 name:NSWindowDidMiniaturizeNotification
+                                             selector:@selector(windowDidChangeOcclusionState:)
+                                                 name:NSWindowDidChangeOcclusionStateNotification
                                                object:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(windowDidDeminiaturize:)
-                                                 name:NSWindowDidDeminiaturizeNotification
-                                               object:nil];
 
     // setup main box subviews animation
     // XXX: Creates a null first item
@@ -1378,30 +1374,27 @@
 
 
 #pragma mark -
-#pragma mark Application Notification (Private)
+#pragma mark Window Notification (Private)
 
-- (void)windowDidMiniaturize:(NSNotification *)notification {
+- (void)windowDidChangeOcclusionState:(NSNotification *)notification {
     NSWindow *sender = [notification object];
     if ([sender isEqual:self.window]) {
-        [self uninstallProgressTimer];
+        BOOL visible = self.window.occlusionState & NSWindowOcclusionStateVisible;
+        if (visible) {
+            [self installProgressTimer];
+        }
+        else {
+            [self uninstallProgressTimer];
+        }
     }
 }
 
-- (void)windowDidDeminiaturize:(NSNotification *)notification {
-    NSWindow *sender = [notification object];
-    if ([sender isEqual:self.window]) {
-        [self installProgressTimer];
-    }
-}
+
 
 
 
 
 #pragma mark -
-
-
-
-
 #pragma mark Player Notifications (Private)
 
 - (void)playerPlaylistUpdatedNotification:(NSNotification *)notification {

--- a/Submariner/SBPlayer.swift
+++ b/Submariner/SBPlayer.swift
@@ -758,7 +758,7 @@ extension NSNotification.Name {
     }
     
     @objc var currentTimeString: String {
-        return String(time: currentTime)
+        return String(timeInterval: currentTime)
     }
     
     @objc var durationTime: TimeInterval {
@@ -782,7 +782,7 @@ extension NSNotification.Name {
     }
     
     @objc var remainingTimeString: String {
-        return String(time: remainingTime)
+        return String(timeInterval: remainingTime)
     }
     
     @objc var progress: Double {

--- a/Submariner/SBTrack.swift
+++ b/Submariner/SBTrack.swift
@@ -26,7 +26,7 @@ public class SBTrack: SBMusicItem {
     
     @objc var durationString: String? {
         self.willAccessValue(forKey: "duration")
-        let ret = String(time: TimeInterval(duration?.intValue ?? 0))
+        let ret = String(timeInterval: TimeInterval(duration?.intValue ?? 0))
         self.didAccessValue(forKey: "duration")
         return ret
     }

--- a/Submariner/String+Time.swift
+++ b/Submariner/String+Time.swift
@@ -34,12 +34,22 @@ extension String {
         return String.rfc3339DateFormatter.date(from: self as String)
     }
     
-    init(time: TimeInterval) {
-        if time == 0 || time.isNaN {
-            self = "0:00"
+    init(timeInterval: TimeInterval) {
+        if timeInterval == 0 || timeInterval.isNaN {
+            self = "00:00"
             return
         }
+
+        let ti = Int(timeInterval)
+        let seconds = ti % 60
+        let minutes = (ti / 60) % 60
+        let hours = (ti / 3600)
         
-        self = String.componentFormatter.string(from: time)!
+        if (hours > 0) {
+            self = String(format: "%0.2d:%0.2d:%0.2d", hours, minutes, seconds);
+        }
+        else {
+            self = String(format: "%0.2d:%0.2d", minutes, seconds);
+        }
     }
 }


### PR DESCRIPTION
* Don't update progress when player is paused
* Don't update progress when the main window is not visible.
* Replace `componentFormatter` with simple implementation to reduce overhead.