### PR TITLE
Use tag instead of directory based metadata

### DIFF
--- a/Submariner/SBClientController.swift
+++ b/Submariner/SBClientController.swift
@@ -325,7 +325,7 @@ fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, catego
         params["query"] = query
         params["songCount"] = "100" // XXX: Configurable? Pagination?
         
-        let url = URL.URLWith(string: server.url, command: "rest/search2.view", parameters: params)
+        let url = URL.URLWith(string: server.url, command: "rest/search3.view", parameters: params)
         request(url: url, type: .search) { operation in
             operation.currentSearch = SBSearchResult(query: query)
         }

--- a/Submariner/SBClientController.swift
+++ b/Submariner/SBClientController.swift
@@ -136,6 +136,11 @@ fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, catego
         request(url: url, type: .getIndexes)
     }
     
+    func getArtists() {
+        let url = URL.URLWith(string: server.url, command: "rest/getArtists.view", parameters: parameters)
+        request(url: url, type: .getIndexes)
+    }
+    
     @objc(getAlbumsForArtist:) func getAlbums(artist: SBArtist) {
         var params = parameters
         if artist.itemId == nil {
@@ -147,6 +152,21 @@ fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, catego
         
         let url = URL.URLWith(string: server.url, command: "rest/getMusicDirectory.view", parameters: params)
         request(url: url, type: .getAlbumDirectory) { operation in
+            operation.currentArtistID = artist.itemId
+        }
+    }
+    
+    func get(artist: SBArtist) {
+        var params = parameters
+        if artist.itemId == nil {
+            // can happen because of now playing/search
+
+            return
+        }
+        params["id"] = artist.itemId
+        
+        let url = URL.URLWith(string: server.url, command: "rest/getArtist.view", parameters: params)
+        request(url: url, type: .getArtist) { operation in
             operation.currentArtistID = artist.itemId
         }
     }
@@ -168,6 +188,16 @@ fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, catego
         let url = URL.URLWith(string: server.url, command: "rest/getMusicDirectory.view", parameters: params)
         request(url: url, type: .getTrackDirectory) { operation in
             operation.currentAlbumID = albumID
+        }
+    }
+    
+    func get(album: SBAlbum) {
+        var params = parameters
+        params["id"] = album.itemId
+        
+        let url = URL.URLWith(string: server.url, command: "rest/getAlbum.view", parameters: params)
+        request(url: url, type: .getAlbum) { operation in
+            operation.currentAlbumID = album.itemId
         }
     }
     
@@ -273,7 +303,7 @@ fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, catego
             abort()
         }
         
-        let url = URL.URLWith(string: server.url, command: "rest/getAlbumList.view", parameters: params)
+        let url = URL.URLWith(string: server.url, command: "rest/getAlbumList2.view", parameters: params)
         request(url: url, type: type)
     }
     

--- a/Submariner/SBClientController.swift
+++ b/Submariner/SBClientController.swift
@@ -123,37 +123,9 @@ fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, catego
         request(url: url, type: .getLicense)
     }
     
-    @objc func getIndexes() {
-        let url = URL.URLWith(string: server.url, command: "rest/getIndexes.view", parameters: parameters)
-        request(url: url, type: .getIndexes)
-    }
-    
-    @objc(getIndexesSince:) func getIndexes(since: Date) {
-        var params = parameters
-        params["ifModifiedSince"] = String(format: "%00.f", since.timeIntervalSince1970 * 1000)
-        
-        let url = URL.URLWith(string: server.url, command: "rest/getIndexes.view", parameters: params)
-        request(url: url, type: .getIndexes)
-    }
-    
     func getArtists() {
         let url = URL.URLWith(string: server.url, command: "rest/getArtists.view", parameters: parameters)
         request(url: url, type: .getIndexes)
-    }
-    
-    @objc(getAlbumsForArtist:) func getAlbums(artist: SBArtist) {
-        var params = parameters
-        if artist.itemId == nil {
-            // can happen because of now playing/search
-
-            return
-        }
-        params["id"] = artist.itemId
-        
-        let url = URL.URLWith(string: server.url, command: "rest/getMusicDirectory.view", parameters: params)
-        request(url: url, type: .getAlbumDirectory) { operation in
-            operation.currentArtistID = artist.itemId
-        }
     }
     
     func get(artist: SBArtist) {

--- a/Submariner/SBClientController.swift
+++ b/Submariner/SBClientController.swift
@@ -125,7 +125,7 @@ fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, catego
     
     func getArtists() {
         let url = URL.URLWith(string: server.url, command: "rest/getArtists.view", parameters: parameters)
-        request(url: url, type: .getIndexes)
+        request(url: url, type: .getArtists)
     }
     
     func get(artist: SBArtist) {

--- a/Submariner/SBClientController.swift
+++ b/Submariner/SBClientController.swift
@@ -153,14 +153,12 @@ fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, catego
         }
     }
     
-    @objc(getTracksForAlbumID:) func getTracks(albumID: String) {
+    func getTrack(trackID: String) {
         var params = parameters
-        params["id"] = albumID
+        params["id"] = trackID
         
-        let url = URL.URLWith(string: server.url, command: "rest/getMusicDirectory.view", parameters: params)
-        request(url: url, type: .getTrackDirectory) { operation in
-            operation.currentAlbumID = albumID
-        }
+        let url = URL.URLWith(string: server.url, command: "rest/getSong.view", parameters: params)
+        request(url: url, type: .getTrack)
     }
     
     func get(album: SBAlbum) {

--- a/Submariner/SBDatabaseController.m
+++ b/Submariner/SBDatabaseController.m
@@ -860,7 +860,7 @@
         return;
     }
     [self.server setSelectedTabIndex: 2];
-    SBNavigationItem *navItem = [[SBServerHomeNavigationItem alloc] initWithServer: self.server];
+    SBNavigationItem *navItem = [[SBServerPodcastsNavigationItem alloc] initWithServer: self.server];
     [self navigateForwardToNavItem: navItem];
 }
 

--- a/Submariner/SBDatabaseController.m
+++ b/Submariner/SBDatabaseController.m
@@ -668,7 +668,7 @@
         return;
     }
     [server getServerLicense];
-    [server getServerIndexes];
+    [server getArtists];
     [server getServerPlaylists];
     // XXX: Check if it's the current VC too?
     if (server != nil && serverHomeController.server == server) {
@@ -1380,7 +1380,7 @@
 - (void)subsonicConnectionSucceeded:(NSNotification *)notification {
     // loading of server content, major !!!
     [self.server getServerLicense];
-    [self.server getServerIndexes];
+    [self.server getArtists];
     [self.server getServerPlaylists];
 }
 

--- a/Submariner/SBEpisode.swift
+++ b/Submariner/SBEpisode.swift
@@ -27,9 +27,9 @@ public class SBEpisode: SBTrack {
            let path = self.path,
            FileManager.default.fileExists(atPath: path) {
             return URL.init(fileURLWithPath: path)
-        } else if let server = self.server, let url = server.url {
+        } else if let server = self.server, let streamID = self.streamID, let url = server.url {
             var parameters = server.getBaseParameters()
-            parameters["id"] = self.itemId
+            parameters["id"] = streamID
             
             return URL.URLWith(string: url, command: "rest/stream.view", parameters: parameters)
         }
@@ -37,9 +37,9 @@ public class SBEpisode: SBTrack {
     }
     
     @objc override func downloadURL() -> URL? {
-        if let server = self.server, let url = server.url {
+        if let server = self.server, let streamID = self.streamID, let url = server.url {
             var parameters = server.getBaseParameters()
-            parameters["id"] = self.itemId
+            parameters["id"] = streamID
             
             return URL.URLWith(string: url, command: "rest/download.view", parameters: parameters)
         }

--- a/Submariner/SBServer.swift
+++ b/Submariner/SBServer.swift
@@ -386,20 +386,16 @@ public class SBServer: SBResource {
     
     // #MARK: - Subsonic Client (Server Data)
     
-    @objc func getServerIndexes() {
-        if let lastIndexesDate = self.lastIndexesDate {
-            self.clientController.getIndexes(since: lastIndexesDate)
-        } else {
-            self.clientController.getIndexes()
-        }
+    @objc func getArtists() {
+        self.clientController.getArtists()
     }
     
-    @objc func getAlbumsFor(artist: SBArtist) {
-        self.clientController.getAlbums(artist: artist)
+    @objc(getArtist:) func get(artist: SBArtist) {
+        self.clientController.get(artist: artist)
     }
     
-    @objc func getTracksFor(albumID: String) {
-        self.clientController.getTracks(albumID: albumID)
+    @objc(getAlbum:) func get(album: SBAlbum) {
+        self.clientController.get(album: album)
     }
     
     @objc func getAlbumListFor(type: SBSubsonicParsingOperation.RequestType) {

--- a/Submariner/SBServerHomeController.m
+++ b/Submariner/SBServerHomeController.m
@@ -382,7 +382,7 @@
             
             // reset current tracks
             [tracksController setContent:nil];
-            [self.server getTracksForAlbumID: album.itemId];
+            [self.server getAlbum: album];
             
             if([album.tracks count] == 0) {   
                 // wait for new tracks

--- a/Submariner/SBServerHomeController.m
+++ b/Submariner/SBServerHomeController.m
@@ -117,9 +117,10 @@
 					  [NSDictionary dictionaryWithObjectsAndKeys: 
                        @"NewestItem", ITEM_IDENTIFIER, 
                        @"Newest", ITEM_NAME, nil],
-                      [NSDictionary dictionaryWithObjectsAndKeys: 
-                       @"HighestItem", ITEM_IDENTIFIER, 
-                       @"Highest", ITEM_NAME, nil],
+                      // "highest" isn't supported by albumList2 in Subsonic or Navidrome for some reason...
+//                      [NSDictionary dictionaryWithObjectsAndKeys:
+//                       @"HighestItem", ITEM_IDENTIFIER,
+//                       @"Highest", ITEM_NAME, nil],
                       [NSDictionary dictionaryWithObjectsAndKeys: 
                        @"FrequentItem", ITEM_IDENTIFIER, 
                        @"Frequent", ITEM_NAME, nil],

--- a/Submariner/SBServerLibraryController.m
+++ b/Submariner/SBServerLibraryController.m
@@ -505,7 +505,7 @@
         if(selectedRow != -1) {
             SBArtist *selectedArtist = [[artistsController arrangedObjects] objectAtIndex:selectedRow];
             if(selectedArtist && [selectedArtist isKindOfClass:[SBArtist class]]) {
-                [self.server getAlbumsForArtist:selectedArtist];
+                [self.server getArtist:selectedArtist];
                 [albumsBrowserView setSelectionIndexes:nil byExtendingSelection:NO];
             }
         }
@@ -618,7 +618,7 @@
         SBAlbum *album = [[albumsController arrangedObjects] objectAtIndex:selectedRow];
         if(album) {
             
-            [self.server getTracksForAlbumID: album.itemId];
+            [self.server getAlbum: album];
             
             if([album.tracks count] == 0) {                
                 // wait for new tracks

--- a/Submariner/SBServerPodcastController.m
+++ b/Submariner/SBServerPodcastController.m
@@ -70,7 +70,7 @@
 - (id)initWithManagedObjectContext:(NSManagedObjectContext *)context {
     self = [super initWithManagedObjectContext:context];
     if (self) {
-        NSSortDescriptor *descr1 = [NSSortDescriptor sortDescriptorWithKey:@"id" ascending:YES];
+        NSSortDescriptor *descr1 = [NSSortDescriptor sortDescriptorWithKey:@"itemId" ascending:YES];
         podcastsSortDescriptors = [[NSArray alloc] initWithObjects:descr1, nil];
         
         NSSortDescriptor *descr2 = [NSSortDescriptor sortDescriptorWithKey:@"publishDate" ascending:NO];

--- a/Submariner/SBSubsonicDownloadOperation.swift
+++ b/Submariner/SBSubsonicDownloadOperation.swift
@@ -86,7 +86,12 @@ fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, catego
         }
         
         // SBImportOperation needs an audio file extension. Rename the file.
-        let fileType = UTType(mimeType: downloadTask.response?.mimeType ?? "audio/mp3") ?? UTType.mp3
+        var proposedMimeType = downloadTask.response?.mimeType
+        if proposedMimeType == "application/x-download" {
+            // XXX: get a better one
+            proposedMimeType = nil
+        }
+        let fileType = UTType(mimeType: proposedMimeType ?? "audio/mp3") ?? UTType.mp3
         let temporaryFile = URL.temporaryFile().appendingPathExtension(for: fileType)
         try! FileManager.default.moveItem(at: location, to: temporaryFile)
         

--- a/Submariner/SBSubsonicParsingOperation.swift
+++ b/Submariner/SBSubsonicParsingOperation.swift
@@ -867,7 +867,6 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
         return album
     }
     
-    // NOT USED YET - this makes sense only if you're using the tag based APIs
     private func updateTrackDependenciesForTag(_ track: SBTrack, attributeDict: [String: String], shouldFetchAlbumArt: Bool = true) {
         var attachedArtist: SBArtist?
         // is this right for album artist? the artist object can get corrected on fetch though...

--- a/Submariner/SBSubsonicParsingOperation.swift
+++ b/Submariner/SBSubsonicParsingOperation.swift
@@ -598,7 +598,7 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
             parseElementDirectory(attributeDict: attributeDict)
         } else if elementName == "child" { // ...and a directory's child item
             parseElementChild(attributeDict: attributeDict)
-        } else if elementName == "albumList" { // the ServerHome controller's album list...
+        } else if elementName == "albumList" || elementName == "albumList2" { // the ServerHome controller's album list...
             parseElementAlbumList(attributeDict: attributeDict)
         } else if elementName == "album" { // ...and its albums
             parseElementAlbum(attributeDict: attributeDict)

--- a/Submariner/SBSubsonicParsingOperation.swift
+++ b/Submariner/SBSubsonicParsingOperation.swift
@@ -404,7 +404,7 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
                 } ?? false
                 logger.info("Adding track (and updating) with ID: \(id, privacy: .public) to playlist \(currentPlaylist.itemId ?? "(no ID?)", privacy: .public), exists? \(exists) index? \(self.playlistIndex)")
                 
-                updateTrackDependenciesForDirectoryIndex(track, attributeDict: attributeDict, shouldFetchAlbumArt: false)
+                updateTrackDependenciesForTag(track, attributeDict: attributeDict, shouldFetchAlbumArt: false)
                 
                 // limitation if the same track exists twice
                 track.playlistIndex = NSNumber(value: playlistIndex)
@@ -419,7 +419,7 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
                 // FIXME: Should we update *existing* tracks regardless? For previous cases they were pulled anew...
                 logger.info("Creating new track with ID: \(id, privacy: .public) for playlist \(currentPlaylist.itemId ?? "(no ID?)", privacy: .public)")
                 let track = createTrack(attributes: attributeDict)
-                updateTrackDependenciesForDirectoryIndex(track, attributeDict: attributeDict, shouldFetchAlbumArt: false)
+                updateTrackDependenciesForTag(track, attributeDict: attributeDict, shouldFetchAlbumArt: false)
                 
                 track.playlistIndex = NSNumber(value: playlistIndex)
                 playlistIndex += 1

--- a/Submariner/SBSubsonicParsingOperation.swift
+++ b/Submariner/SBSubsonicParsingOperation.swift
@@ -233,7 +233,7 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
             }
             logger.info("Creating new artist with ID: \(id, privacy: .public) and name \(name, privacy: .public)")
             // we don't do anything with the return value since it gets put into core data
-            let artist = createArtist(attributes: attributeDict)
+            _ = createArtist(attributes: attributeDict)
         }
     }
     
@@ -270,7 +270,7 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
             currentArtist.addToAlbums(album!)
             
             // the track may not have a cover assigned yet
-            if let cover = album!.cover {
+            if album!.cover != nil {
                 // the album already has a cover
                 logger.info("Album ID \(id, privacy: .public) already has a cover")
             } else if let coverID = attributeDict["coverArt"],
@@ -571,7 +571,7 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
             
             // FIXME: yeah, this is how it was before, it doesn't make much sense
             if let streamID = attributeDict["streamId"] {
-                var track = fetchTrack(id: streamID)
+                let track = fetchTrack(id: streamID)
                 if track == nil, let albumID = attributeDict["parent"] {
                     clientController.getTracks(albumID: albumID)
                 } else {

--- a/Submariner/SBSubsonicParsingOperation.swift
+++ b/Submariner/SBSubsonicParsingOperation.swift
@@ -373,8 +373,10 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
             }
             
             // always reassociate due to possible transitions
-            album!.artist = artist
-            artist?.addToAlbums(album!)
+            if artist != nil {
+                album!.artist = artist
+                artist?.addToAlbums(album!)
+            }
             server.home?.addToAlbums(album!)
             album!.home = server.home
             

--- a/Submariner/SBSubsonicParsingOperation.swift
+++ b/Submariner/SBSubsonicParsingOperation.swift
@@ -188,12 +188,27 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
                 return
             }
             
-            if let currentPlaylistID = self.currentPlaylistID, let playlistToDelete = fetchPlaylist(id: currentPlaylistID) {
-                threadedContext.delete(playlistToDelete)
-            } else if let currentArtistID = self.currentArtistID, let artistToDelete = fetchArtist(id: currentArtistID) {
-                threadedContext.delete(artistToDelete)
-            } else if let currentAlbumID = self.currentAlbumID, let albumToDelete = fetchAlbum(id: currentAlbumID) {
-                threadedContext.delete(albumToDelete)
+            if let currentPlaylistID = self.currentPlaylistID {
+                logger.info("Didn't find playlist on server w/ ID of \(currentPlaylistID, privacy: .public)")
+                if let playlistToDelete = fetchPlaylist(id: currentPlaylistID) {
+                    logger.info("Removing playlist that wasn't found on server w/ ID of \(currentPlaylistID, privacy: .public)")
+                    threadedContext.delete(playlistToDelete)
+                }
+                return
+            } else if let currentArtistID = self.currentArtistID {
+                logger.info("Didn't find artist on server w/ ID of \(currentArtistID, privacy: .public)")
+                if let artistToDelete = fetchArtist(id: currentArtistID) {
+                    logger.info("Removing artist that wasn't found on server w/ ID of \(currentArtistID, privacy: .public)")
+                    threadedContext.delete(artistToDelete)
+                }
+                return
+            } else if let currentAlbumID = self.currentAlbumID {
+                logger.info("Didn't find album on server w/ ID of \(currentAlbumID, privacy: .public)")
+                if let albumToDelete = fetchAlbum(id: currentAlbumID) {
+                    logger.info("Removing album that wasn't found on server w/ ID of \(currentAlbumID, privacy: .public)")
+                    threadedContext.delete(albumToDelete)
+                }
+                return
             }
             // XXX: Cover, podcast, track? Do we need to remove it from any sets?
         }

--- a/Submariner/SBSubsonicParsingOperation.swift
+++ b/Submariner/SBSubsonicParsingOperation.swift
@@ -588,7 +588,7 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
             parseElementSubsonicResponse(attributeDict: attributeDict)
         } else if elementName == "error" {
             parseElementError(attributeDict: attributeDict)
-        } else if elementName == "indexes" {
+        } else if elementName == "indexes" || elementName == "artists" { // directory or tag based index...
             parseElementIndexes(attributeDict: attributeDict)
         } else if elementName == "index" { // build group index
             parseElementIndex(attributeDict: attributeDict)

--- a/Submariner/SBSubsonicParsingOperation.swift
+++ b/Submariner/SBSubsonicParsingOperation.swift
@@ -218,7 +218,10 @@ class SBSubsonicParsingOperation: SBOperation, XMLParserDelegate {
     
     private func parseElementArtist(attributeDict: [String: String]) {
         if let id = attributeDict["id"], let name = attributeDict["name"] {
-            if fetchArtist(id: id) != nil {
+            if let existingArtist = fetchArtist(id: id) {
+                // doing this in ID3 migration, but may be useful if servers keep ID if artist renames
+                // i.e. "British Sea Power" -> "Sea Power" (and avoid deadnames, etc.)
+                existingArtist.itemName = name
                 return
             }
             // for cases where we have artists without IDs from i.e. getNowPlaying/search2


### PR DESCRIPTION
Avoids the ugly contorting of the data model from arbitrary directory structure to artist-album-track. This should make the API requests actually match the original data model.

- I have only tested with Navidrome. Since Navidrome uses identical IDs for the fake hierarchy and the tags, the transition is seamless.
- I haven't tested Subsonic. Since it uses different IDs for directories vs. tags, it's likely this won't be so smooth. Recreate your server. (Could this be handled better?)
- Nor have I tested other implementations.
- Podcasts may be busted. The podcast functionality is really bitrotted and not well tested regardless.
- We could do real directory hierarchies (GH-173) correctly, with a data model actually modelling... directories.

Fixes GH-73