### PR TITLE
Use built into Sonoma column hiding menu

### DIFF
--- a/Submariner/MusicSearch.xib
+++ b/Submariner/MusicSearch.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22155" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22155"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -153,6 +153,7 @@
                                     </tableColumn>
                                 </tableColumns>
                                 <connections>
+                                    <outlet property="delegate" destination="-2" id="ipU-Bn-KI0"/>
                                     <outlet property="menu" destination="paR-xu-VXT" id="K9F-dr-6i0"/>
                                 </connections>
                             </tableView>
@@ -171,7 +172,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </tableHeaderView>
                 </scrollView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="o3e-Kv-DpN">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="o3e-Kv-DpN">
                     <rect key="frame" x="18" y="13" width="606" height="16"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="truncatingTail" alignment="center" title="Track length" id="gKj-iU-7qy">

--- a/Submariner/SBMusicController.m
+++ b/Submariner/SBMusicController.m
@@ -725,6 +725,14 @@
 }
 
 
+#pragma mark - NSTableView (Columns)
+
+
+- (BOOL)tableView:(NSTableView *)tableView userCanChangeVisibilityOfTableColumn:(NSTableColumn *)column {
+    return YES;
+}
+
+
 #pragma mark -
 #pragma mark NSTableView Sort Descriptor Override
 

--- a/Submariner/SBMusicSearchController.m
+++ b/Submariner/SBMusicSearchController.m
@@ -160,6 +160,14 @@
 }
 
 
+#pragma mark - NSTableView (Columns)
+
+
+- (BOOL)tableView:(NSTableView *)tableView userCanChangeVisibilityOfTableColumn:(NSTableColumn *)column {
+    return YES;
+}
+
+
 #pragma mark -
 #pragma mark UI Validator
 

--- a/Submariner/SBPlaylistController.m
+++ b/Submariner/SBPlaylistController.m
@@ -212,6 +212,12 @@
 }
 
 
+#pragma mark - NSTableView (Columns)
+
+
+- (BOOL)tableView:(NSTableView *)tableView userCanChangeVisibilityOfTableColumn:(NSTableColumn *)column {
+    return YES;
+}
 
 
 #pragma mark -

--- a/Submariner/SBServerHomeController.m
+++ b/Submariner/SBServerHomeController.m
@@ -403,8 +403,12 @@
 }
 
 
+#pragma mark - NSTableView (Columns)
 
 
+- (BOOL)tableView:(NSTableView *)tableView userCanChangeVisibilityOfTableColumn:(NSTableColumn *)column {
+    return YES;
+}
 
 
 #pragma mark -

--- a/Submariner/SBServerLibraryController.m
+++ b/Submariner/SBServerLibraryController.m
@@ -529,6 +529,13 @@
 }
 
 
+#pragma mark - NSTableView (Columns)
+
+
+- (BOOL)tableView:(NSTableView *)tableView userCanChangeVisibilityOfTableColumn:(NSTableColumn *)column {
+    return YES;
+}
+
 
 #pragma mark -
 #pragma mark NSTableView (Drag & Drop)

--- a/Submariner/SBServerSearchController.m
+++ b/Submariner/SBServerSearchController.m
@@ -183,6 +183,14 @@
 
 
 
+#pragma mark - NSTableView (Columns)
+
+
+- (BOOL)tableView:(NSTableView *)tableView userCanChangeVisibilityOfTableColumn:(NSTableColumn *)column {
+    return YES;
+}
+
+
 #pragma mark -
 #pragma mark NSTableView (Drag & Drop)
 

--- a/Submariner/SBTableView.m
+++ b/Submariner/SBTableView.m
@@ -39,9 +39,13 @@
 
 - (void)awakeFromNib {
     [super awakeFromNib];
-    // don't override an existing menu
-    if (self.autosaveName != nil && self.headerView.menu == nil) {
-        [self createViewHeaderMenu];
+    if (@available(macOS 14.0, *)) {
+        // use built into sonoma feature instead
+    } else {
+        // don't override an existing menu
+        if (self.autosaveName != nil && self.headerView.menu == nil) {
+            [self createViewHeaderMenu];
+        }
     }
 }
 


### PR DESCRIPTION
Not sure if I want to use it fully yet. It won't show columns with no user visible label in the list (i..e the playback/synced icons) though.